### PR TITLE
Add godoc reference badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Datastore Wrapper
+# Datastore Wrapper [![Go Documentation](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)][godoc]
+
+[godoc]: https://godoc.org/go.mercari.io/datastore
 
 :construction: This package is unstable :construction: [github repo](https://github.com/mercari/datastore)
 


### PR DESCRIPTION
Add a godoc reference badge next to the title.
Follows https://github.com/mercari/go-httpdoc.

![2017-11-09 19 41 31](https://user-images.githubusercontent.com/10068231/32601465-0ef9f3c4-c586-11e7-95f9-15fc676aafe3.png)
