### PR TITLE
feat(boom): add NewQuery method

### DIFF
--- a/boom/boom.go
+++ b/boom/boom.go
@@ -496,3 +496,7 @@ func (bm *Boom) Batch() *Batch {
 func (bm *Boom) DecodeCursor(s string) (datastore.Cursor, error) {
 	return bm.Client.DecodeCursor(s)
 }
+
+func (bm *Boom) NewQuery(k string) datastore.Query {
+	return bm.Client.NewQuery(k)
+}

--- a/boom/boom_test.go
+++ b/boom/boom_test.go
@@ -432,7 +432,7 @@ func TestBoom_Count(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	q := client.NewQuery(bm.Kind(&Data{}))
+	q := bm.NewQuery(bm.Kind(&Data{}))
 	cnt, err := bm.Count(q)
 	if err != nil {
 		t.Fatal(err)
@@ -465,7 +465,7 @@ func TestBoom_GetAll(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	q := client.NewQuery(bm.Kind(&Data{}))
+	q := bm.NewQuery(bm.Kind(&Data{}))
 	{
 		list = make([]*Data, 0)
 		_, err = bm.GetAll(q, &list)

--- a/boom/query_test.go
+++ b/boom/query_test.go
@@ -26,7 +26,7 @@ func TestBoom_IteratorNext(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	q := client.NewQuery(bm.Kind(&Data{}))
+	q := bm.NewQuery(bm.Kind(&Data{}))
 	it := bm.Run(q)
 
 	for {
@@ -68,7 +68,7 @@ func TestBoom_IteratorNextKeysOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	q := client.NewQuery(bm.Kind(&Data{})).KeysOnly()
+	q := bm.NewQuery(bm.Kind(&Data{})).KeysOnly()
 	it := bm.Run(q)
 
 	for {


### PR DESCRIPTION
Added `NewQuery`, that wraps datastore.Client method to boom package.