### PR TITLE
[DON'T MERGE] tx+boom+ID specification -> panic!!!

### DIFF
--- a/testsuite/suite.go
+++ b/testsuite/suite.go
@@ -51,6 +51,7 @@ var TestSuite = map[string]Test{
 	"TransactionBatch_PutAndAllocateIDs":        TransactionBatch_PutAndAllocateIDs,
 	"TransactionBatch_Get":                      TransactionBatch_Get,
 	"TransactionBatch_Delete":                   TransactionBatch_Delete,
+	"Transaction_WithBoom":                      Transaction_WithBoom,
 }
 
 func MergeTestSuite(suite map[string]Test) {

--- a/testsuite/transaction.go
+++ b/testsuite/transaction.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"go.mercari.io/datastore"
+	"go.mercari.io/datastore/boom"
 )
 
 func Transaction_Commit(t *testing.T, ctx context.Context, client datastore.Client) {
@@ -270,6 +271,37 @@ func RunInTransaction_Rollback(t *testing.T, ctx context.Context, client datasto
 		return errors.New("This tx should failure")
 	})
 	if err == nil {
+		t.Fatal(err)
+	}
+}
+
+func Transaction_WithBoom(t *testing.T, ctx context.Context, client datastore.Client) {
+	defer func() {
+		err := client.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	bm := boom.FromClient(ctx, client)
+
+	type Data struct {
+		ID string `boom:"id" datastore:"-"`
+	}
+
+	tx, err := bm.NewTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = tx.PutMulti([]*Data{&Data{
+		ID: "hoge",
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = tx.Commit()
+	if err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
If tx is executed with boom and put is done with ID specified, panic will be generated.
I added UnitTest which can reproduce it.

```
2017/12/05 19:51:54 appengine: not running under devappserver2; using some default configuration
panic: PendingKey was not created by corresponding transaction [recovered]
	panic: PendingKey was not created by corresponding transaction

goroutine 861 [running]:
testing.tRunner.func1(0xc420236b60)
	/Users/sinmetal/bin/google-cloud-sdk/platform/google_appengine/goroot-1.8/src/testing/testing.go:622 +0x29d
panic(0x159a6a0, 0xc420405c60)
	/Users/sinmetal/bin/google-cloud-sdk/platform/google_appengine/goroot-1.8/src/runtime/panic.go:489 +0x2cf
go.mercari.io/datastore/vendor/cloud.google.com/go/datastore.(*Commit).Key(0x1a01b78, 0xc4201bccb0, 0xc4201bccb0)
	/Users/sinmetal/go/src/go.mercari.io/datastore/vendor/cloud.google.com/go/datastore/transaction.go:300 +0x89
go.mercari.io/datastore/clouddatastore.(*commitImpl).Key(0xc420406678, 0x19993c0, 0xc42022a1f0, 0x0, 0x0)
	/Users/sinmetal/go/src/go.mercari.io/datastore/clouddatastore/transaction.go:145 +0x50
go.mercari.io/datastore/boom.(*Transaction).Commit(0xc4201eeec0, 0x0, 0x0, 0x0, 0x0)
	/Users/sinmetal/go/src/go.mercari.io/datastore/boom/transaction.go:122 +0x11c
go.mercari.io/datastore/testsuite.Transaction_WithBoom(0xc420236b60, 0x19a57c0, 0xc4204269f0, 0x19aa540, 0xc4204269c0)
	/Users/sinmetal/go/src/go.mercari.io/datastore/testsuite/transaction.go:303 +0x29e
go.mercari.io/datastore/clouddatastore.TestCloudDatastoreTestSuite.func1(0xc420236b60)
	/Users/sinmetal/go/src/go.mercari.io/datastore/clouddatastore/testsuite_test.go:65 +0x17e
testing.tRunner(0xc420236b60, 0xc420507520)
	/Users/sinmetal/bin/google-cloud-sdk/platform/google_appengine/goroot-1.8/src/testing/testing.go:657 +0x96
created by testing.(*T).Run
	/Users/sinmetal/bin/google-cloud-sdk/platform/google_appengine/goroot-1.8/src/testing/testing.go:697 +0x2ca
```