### PR TITLE
[WIP] Improve read performance from memcache

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -63,6 +63,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/mjibson/goon"
+  packages = ["."]
+  revision = "0cd9745d6b9c43c1de754769708fb2ac349d84b2"
+
+[[projects]]
+  branch = "master"
   name = "golang.org/x/net"
   packages = ["context","context/ctxhttp","http2","http2/hpack","idna","internal/timeseries","lex/httplex","trace"]
   revision = "a8b9294777976932365dabb6640cf1468d95c70f"
@@ -124,6 +130,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "426cf888b16f028a3db798b87981aa2854d212d3823f0d7d890bcb1577dfe4a5"
+  inputs-digest = "bbb9b138043e161e6ed269dfcb5ed5c841b617b22501295cc60bf4fd508233c2"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/benchmark/vs_goon/vs_test.go
+++ b/benchmark/vs_goon/vs_test.go
@@ -165,3 +165,149 @@ func BenchmarkBoomFromAEMemcache(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkGoonFromLocalCache(b *testing.B) {
+	_, ctx, err := testerator.SpinUp()
+	if err != nil {
+		b.Fatal(err.Error())
+	}
+	defer testerator.SpinDown()
+
+	type Data struct {
+		ID        int64 `datastore:"-" goon:"id"`
+		Name      string
+		N1        int
+		N2        int
+		N3        int
+		N4        int
+		N5        int
+		N6        int
+		N7        int
+		N8        int
+		N9        int
+		N10       int
+		CreatedAt time.Time
+	}
+
+	const size = 300
+
+	g := goon.FromContext(ctx)
+
+	// データの用意
+	list := make([]*Data, 0, size)
+	for i := 0; i < size; i++ {
+		list = append(list, &Data{
+			Name:      fmt.Sprintf("#%d", i+1),
+			CreatedAt: time.Now(),
+		})
+	}
+	keys, err := g.PutMulti(list)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// LocalCacheに載せる
+	list = make([]*Data, 0, size)
+	for idx := range list {
+		list = append(list, &Data{
+			ID: keys[idx].IntID(),
+		})
+	}
+	err = g.GetMulti(list)
+	if err != nil {
+		b.Fatal(err.Error())
+	}
+
+	b.ResetTimer()
+
+	// LocalCacheからGetする時のベンチマーク
+	for i := 0; i < b.N; i++ {
+		list = make([]*Data, 0, size)
+		for i := 0; i < size; i++ {
+			list = append(list, &Data{
+				ID: keys[i].IntID(),
+			})
+		}
+		err = g.GetMulti(list)
+		if err != nil {
+			b.Fatal(err.Error())
+		}
+	}
+}
+func BenchmarkBoomFromLocalCache(b *testing.B) {
+	_, ctx, err := testerator.SpinUp()
+	if err != nil {
+		b.Fatal(err.Error())
+	}
+	defer testerator.SpinDown()
+
+	client, err := aedatastore.FromContext(ctx)
+	if err != nil {
+		b.Fatal(err.Error())
+	}
+
+	lc := localcache.New()
+	lc.Logf = func(ctx context.Context, format string, args ...interface{}) {}
+	client.AppendMiddleware(lc)
+
+	type Data struct {
+		ID        int64 `datastore:"-" goon:"id"`
+		Name      string
+		N1        int
+		N2        int
+		N3        int
+		N4        int
+		N5        int
+		N6        int
+		N7        int
+		N8        int
+		N9        int
+		N10       int
+		CreatedAt time.Time
+	}
+
+	const size = 300
+
+	bm := boom.FromClient(ctx, client)
+
+	// データの用意
+	list := make([]*Data, 0, size)
+	for i := 0; i < size; i++ {
+		list = append(list, &Data{
+			Name:      fmt.Sprintf("#%d", i+1),
+			CreatedAt: time.Now(),
+		})
+	}
+	keys, err := bm.PutMulti(list)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// LocalCacheに載せる
+	list = make([]*Data, 0, size)
+	for idx := range list {
+		list = append(list, &Data{
+			ID: keys[idx].ID(),
+		})
+	}
+	err = bm.GetMulti(list)
+	if err != nil {
+		b.Fatal(err.Error())
+	}
+
+	b.ResetTimer()
+
+	// LocalCacheからGetする時のベンチマーク
+	for i := 0; i < b.N; i++ {
+		list = make([]*Data, 0, size)
+		for i := 0; i < size; i++ {
+			list = append(list, &Data{
+				ID: keys[i].ID(),
+			})
+		}
+		err = bm.GetMulti(list)
+		if err != nil {
+			b.Fatal(err.Error())
+		}
+	}
+}

--- a/benchmark/vs_goon/vs_test.go
+++ b/benchmark/vs_goon/vs_test.go
@@ -1,0 +1,167 @@
+package vs_goon
+
+import (
+	"fmt"
+	"testing"
+	"time"
+	"github.com/mjibson/goon"
+	"github.com/favclip/testerator"
+	"go.mercari.io/datastore/aedatastore"
+	"go.mercari.io/datastore/dsmiddleware/aememcache"
+	"go.mercari.io/datastore/boom"
+	"go.mercari.io/datastore/dsmiddleware/localcache"
+	"context"
+)
+
+func BenchmarkGoonFromAEMemcache(b *testing.B) {
+	_, ctx, err := testerator.SpinUp()
+	if err != nil {
+		b.Fatal(err.Error())
+	}
+	defer testerator.SpinDown()
+
+	type Data struct {
+		ID        int64 `datastore:"-" goon:"id"`
+		Name      string
+		N1        int
+		N2        int
+		N3        int
+		N4        int
+		N5        int
+		N6        int
+		N7        int
+		N8        int
+		N9        int
+		N10       int
+		CreatedAt time.Time
+	}
+
+	const size = 300
+
+	g := goon.FromContext(ctx)
+
+	// データの用意
+	list := make([]*Data, 0, size)
+	for i := 0; i < size; i++ {
+		list = append(list, &Data{
+			Name:      fmt.Sprintf("#%d", i+1),
+			CreatedAt: time.Now(),
+		})
+	}
+	keys, err := g.PutMulti(list)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// Memcacheに載せる
+	list = make([]*Data, 0, size)
+	for idx := range list {
+		list = append(list, &Data{
+			ID: keys[idx].IntID(),
+		})
+	}
+	err = g.GetMulti(list)
+	if err != nil {
+		b.Fatal(err.Error())
+	}
+
+	b.ResetTimer()
+
+	// MemcacheからGetする時のベンチマーク
+	for i := 0; i < b.N; i++ {
+		g.FlushLocalCache()
+		list = make([]*Data, 0, size)
+		for i := 0; i < size; i++ {
+			list = append(list, &Data{
+				ID: keys[i].IntID(),
+			})
+		}
+		err = g.GetMulti(list)
+		if err != nil {
+			b.Fatal(err.Error())
+		}
+	}
+}
+
+func BenchmarkBoomFromAEMemcache(b *testing.B) {
+	_, ctx, err := testerator.SpinUp()
+	if err != nil {
+		b.Fatal(err.Error())
+	}
+	defer testerator.SpinDown()
+
+	client, err := aedatastore.FromContext(ctx)
+	if err != nil {
+		b.Fatal(err.Error())
+	}
+
+	lc := localcache.New()
+	lc.Logf = func(ctx context.Context, format string, args ...interface{}) {}
+	client.AppendMiddleware(lc)
+
+	am := aememcache.New()
+	am.Logf = func(ctx context.Context, format string, args ...interface{}) {}
+	client.AppendMiddleware(am)
+
+	type Data struct {
+		ID        int64 `datastore:"-" goon:"id"`
+		Name      string
+		N1        int
+		N2        int
+		N3        int
+		N4        int
+		N5        int
+		N6        int
+		N7        int
+		N8        int
+		N9        int
+		N10       int
+		CreatedAt time.Time
+	}
+
+	const size = 300
+
+	bm := boom.FromClient(ctx, client)
+
+	// データの用意
+	list := make([]*Data, 0, size)
+	for i := 0; i < size; i++ {
+		list = append(list, &Data{
+			Name:      fmt.Sprintf("#%d", i+1),
+			CreatedAt: time.Now(),
+		})
+	}
+	keys, err := bm.PutMulti(list)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// Memcacheに載せる
+	list = make([]*Data, 0, size)
+	for idx := range list {
+		list = append(list, &Data{
+			ID: keys[idx].ID(),
+		})
+	}
+	err = bm.GetMulti(list)
+	if err != nil {
+		b.Fatal(err.Error())
+	}
+
+	b.ResetTimer()
+
+	// MemcacheからGetする時のベンチマーク
+	for i := 0; i < b.N; i++ {
+		lc.FlushLocalCache()
+		list = make([]*Data, 0, size)
+		for i := 0; i < size; i++ {
+			list = append(list, &Data{
+				ID: keys[i].ID(),
+			})
+		}
+		err = bm.GetMulti(list)
+		if err != nil {
+			b.Fatal(err.Error())
+		}
+	}
+}

--- a/benchmark/vs_goon/vs_test.go
+++ b/benchmark/vs_goon/vs_test.go
@@ -1,24 +1,21 @@
 package vs_goon
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
+
 	"github.com/mjibson/goon"
-	"github.com/favclip/testerator"
-	"go.mercari.io/datastore/aedatastore"
-	"go.mercari.io/datastore/dsmiddleware/aememcache"
 	"go.mercari.io/datastore/boom"
+	"go.mercari.io/datastore/dsmiddleware/aememcache"
 	"go.mercari.io/datastore/dsmiddleware/localcache"
-	"context"
+	"go.mercari.io/datastore/internal/testutils"
 )
 
 func BenchmarkGoonFromAEMemcache(b *testing.B) {
-	_, ctx, err := testerator.SpinUp()
-	if err != nil {
-		b.Fatal(err.Error())
-	}
-	defer testerator.SpinDown()
+	ctx, _, cleanUp := testutils.SetupAEDatastore(b)
+	defer cleanUp()
 
 	type Data struct {
 		ID        int64 `datastore:"-" goon:"id"`
@@ -84,16 +81,8 @@ func BenchmarkGoonFromAEMemcache(b *testing.B) {
 }
 
 func BenchmarkBoomFromAEMemcache(b *testing.B) {
-	_, ctx, err := testerator.SpinUp()
-	if err != nil {
-		b.Fatal(err.Error())
-	}
-	defer testerator.SpinDown()
-
-	client, err := aedatastore.FromContext(ctx)
-	if err != nil {
-		b.Fatal(err.Error())
-	}
+	ctx, client, cleanUp := testutils.SetupAEDatastore(b)
+	defer cleanUp()
 
 	lc := localcache.New()
 	lc.Logf = func(ctx context.Context, format string, args ...interface{}) {}
@@ -167,11 +156,8 @@ func BenchmarkBoomFromAEMemcache(b *testing.B) {
 }
 
 func BenchmarkGoonFromLocalCache(b *testing.B) {
-	_, ctx, err := testerator.SpinUp()
-	if err != nil {
-		b.Fatal(err.Error())
-	}
-	defer testerator.SpinDown()
+	ctx, _, cleanUp := testutils.SetupAEDatastore(b)
+	defer cleanUp()
 
 	type Data struct {
 		ID        int64 `datastore:"-" goon:"id"`
@@ -235,16 +221,8 @@ func BenchmarkGoonFromLocalCache(b *testing.B) {
 	}
 }
 func BenchmarkBoomFromLocalCache(b *testing.B) {
-	_, ctx, err := testerator.SpinUp()
-	if err != nil {
-		b.Fatal(err.Error())
-	}
-	defer testerator.SpinDown()
-
-	client, err := aedatastore.FromContext(ctx)
-	if err != nil {
-		b.Fatal(err.Error())
-	}
+	ctx, client, cleanUp := testutils.SetupAEDatastore(b)
+	defer cleanUp()
 
 	lc := localcache.New()
 	lc.Logf = func(ctx context.Context, format string, args ...interface{}) {}

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -13,11 +13,11 @@ import (
 
 var EmitCleanUpLog = false
 
-func SetupCloudDatastore(t *testing.T) (context.Context, datastore.Client, func()) {
+func SetupCloudDatastore(tb testing.TB) (context.Context, datastore.Client, func()) {
 	ctx := context.Background()
 	client, err := clouddatastore.FromContext(ctx)
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 
 	return ctx, client, func() {
@@ -26,7 +26,7 @@ func SetupCloudDatastore(t *testing.T) (context.Context, datastore.Client, func(
 		q := client.NewQuery("__kind__").KeysOnly()
 		keys, err := client.GetAll(ctx, q, nil)
 		if err != nil {
-			t.Fatal(err)
+			tb.Fatal(err)
 		}
 		if len(keys) == 0 {
 			return
@@ -38,7 +38,7 @@ func SetupCloudDatastore(t *testing.T) (context.Context, datastore.Client, func(
 		}
 
 		if EmitCleanUpLog {
-			t.Logf("remove %s", strings.Join(kinds, ", "))
+			tb.Logf("remove %s", strings.Join(kinds, ", "))
 		}
 
 		for _, kind := range kinds {
@@ -48,18 +48,18 @@ func SetupCloudDatastore(t *testing.T) (context.Context, datastore.Client, func(
 				q := client.NewQuery(kind).Limit(1000).KeysOnly()
 				keys, err := client.GetAll(ctx, q, nil)
 				if err != nil {
-					t.Fatal(err)
+					tb.Fatal(err)
 				}
 				err = client.DeleteMulti(ctx, keys)
 				if err != nil {
-					t.Fatal(err)
+					tb.Fatal(err)
 				}
 
 				cnt += len(keys)
 
 				if len(keys) != 1000 {
 					if EmitCleanUpLog {
-						t.Logf("remove %s entity: %d", kind, cnt)
+						tb.Logf("remove %s entity: %d", kind, cnt)
 					}
 					break
 				}
@@ -68,15 +68,15 @@ func SetupCloudDatastore(t *testing.T) (context.Context, datastore.Client, func(
 	}
 }
 
-func SetupAEDatastore(t *testing.T) (context.Context, datastore.Client, func()) {
+func SetupAEDatastore(tb testing.TB) (context.Context, datastore.Client, func()) {
 	_, ctx, err := testerator.SpinUp()
 	if err != nil {
-		t.Fatal(err.Error())
+		tb.Fatal(err.Error())
 	}
 
 	client, err := aedatastore.FromContext(ctx)
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 
 	return ctx, client, func() { testerator.SpinDown() }


### PR DESCRIPTION
vs goon

```
# in $GOPATH/src/go.mercari.io/datastore/benchmark/vs_goon
$ goapp test -bench . -benchmem -benchtime 10s
BenchmarkGoonFromAEMemcache-8             1000      15112614 ns/op     1591120 B/op       37224 allocs/op
BenchmarkBoomFromAEMemcache-8              300      33531617 ns/op     6717238 B/op      147126 allocs/op

$ goapp test -bench . -benchmem -benchtime 20s
BenchmarkGoonFromAEMemcache-8             2000      13585816 ns/op     1586297 B/op       37119 allocs/op
BenchmarkBoomFromAEMemcache-8             1000      28089797 ns/op     6717331 B/op      147125 allocs/op
```

datastore wrapper is slower than goon x2.2.
goon is caching entity by struct, but datastore wrapper is caching entity by datastore.PropertyList.
datastore.PropertyList will be mapping to struct. It using reflect package. Maybe it is too late.

1. Is this a problem?
2. Can we solve this issue?
